### PR TITLE
Revert "remove useless nconf"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "command-line-args": "^3.0.1",
-    "command-line-usage": "^3.0.3"
+    "command-line-usage": "^3.0.3",
+    "nconf": "^0.8.4"
   }
 }


### PR DESCRIPTION
nconf is used by `bin/wifi.js`

This reverts commit 6400ef48c86a9172ce18374723baa2f0de9d21ee.