### PR TITLE
Fixed channel/frequency in `mac-current-connections.js`

### DIFF
--- a/src/mac-current-connections.js
+++ b/src/mac-current-connections.js
@@ -18,7 +18,7 @@ function parseAirport (stdout) {
         } else if (line.match(/[ ]*link auth: (.*)/)) {
             connection.security = line.match(/[ ]*link auth: (.*)/)[1];
         } else if (line.match(/[ ]*channel: (.*)/)) {
-            connection.frequency = parseInt(networkUtils.frequencyFromChannel(parseInt(line.match(/[ ]*channel: (.*)/)[1])));
+            connection.frequency = parseInt(networkUtils.frequencyFromChannel(parseInt(line.match(/[ ]*channel: (.*)/)[1].split(',')[0])));
             connections.push(connection);
             connection = {};
         }

--- a/src/mac-current-connections.js
+++ b/src/mac-current-connections.js
@@ -17,8 +17,8 @@ function parseAirport (stdout) {
             connection.ssid = line.match(/[ ]*SSID: (.*)/)[1];
         } else if (line.match(/[ ]*link auth: (.*)/)) {
             connection.security = line.match(/[ ]*link auth: (.*)/)[1];
-        } else if (line.match(/[ ]*channel: (.*),(.*)/)) {
-            connection.frequency = parseInt(networkUtils.frequencyFromChannel(parseInt(line.match(/[ ]*channel: (.*),(.*)/)[1])));
+        } else if (line.match(/[ ]*channel: (.*)/)) {
+            connection.frequency = parseInt(networkUtils.frequencyFromChannel(parseInt(line.match(/[ ]*channel: (.*)/)[1])));
             connections.push(connection);
             connection = {};
         }


### PR DESCRIPTION
For some reason at first this worked just fine but when i started using `node-wifi` in Electron, i wasn't able to get any connections with this.

This change i've made fixed the issue, at least for me.

macOS Sierra, version: 10.12.4 (16E195)

I couldn't decide which is better:
```javascript
connection.frequency = parseInt(networkUtils.frequencyFromChannel(parseInt(line.match(/[ ]*channel: (.*)/)[1])));
```
or:
```javascript
connection.frequency = parseInt(networkUtils.frequencyFromChannel(parseInt(line.match(/[ ]*channel: (.*)/)[1].split(',')[0])));
```