### PR TITLE
Bug fix: if it is using the iface option, nmcli cannot connect or scan

### DIFF
--- a/src/linux-connect.js
+++ b/src/linux-connect.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
     	    " password " + "'" + ap.password + "'" ;
 
     	if (config.iface) {
-    	    commandStr = commandStr + " iface " + config.iface;
+    	    commandStr = commandStr + " ifname " + config.iface;
     	}
 
         // commandStr = escapeShell(commandStr);

--- a/src/linux-scan.js
+++ b/src/linux-scan.js
@@ -12,7 +12,7 @@ function scanWifi(config) {
         var commandStr = "nmcli -f all -m multiline dev wifi list";
 
         if (config.iface) {
-            commandStr += ' iface '+config.iface;
+            commandStr += ' ifname '+config.iface;
         }
 
     	exec(commandStr, env, function(err, scanResults) {


### PR DESCRIPTION
If the **iface** is setted to another interface (ie: wlan2), **nmcli** cannot use the setted interface because the correct option is **ifname** and not **iface**.